### PR TITLE
Add support for atom-django

### DIFF
--- a/lib/linter-python-pep8.coffee
+++ b/lib/linter-python-pep8.coffee
@@ -3,7 +3,7 @@ console.log(linterPath)
 Linter = require "#{linterPath}/lib/linter"
 
 class Pep8Linter extends Linter
-  @syntax: ['source.python']
+  @syntax: ['source.python', 'source.python.django']
 
   cmd: 'pep8'
 


### PR DESCRIPTION
Added 'source.python.django' to syntax so that pep8 validation can also be done within Python Django projects
